### PR TITLE
🐛 Return correct data from stats repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `RuneStat\RS3\Stats\Repository::getTotalLevel()` was returning the players total experience and vice-versa. It now returns the correct data
+
 ## [v0.1.0](https://github.com/RuneStat/runescape-api/releases/tag/v0.1.0)
 
 ### Added

--- a/src/RS3/Stats/Repository.php
+++ b/src/RS3/Stats/Repository.php
@@ -134,8 +134,8 @@ class Repository implements IteratorAggregate
         });
 
         return new static(
-            $raw['totalxp'],
             $raw['totalskill'],
+            $raw['totalxp'],
             (int) preg_replace('/[^0-9]/', '', $raw['rank']),
             ...$stats
         );

--- a/tests/RS3/Stats/RepositoryTest.php
+++ b/tests/RS3/Stats/RepositoryTest.php
@@ -50,7 +50,7 @@ class RepositoryTest extends TestCase
 
         $this->repository = new Repository(
             27,
-            27,
+            5400000000,
             27081,
             new Stat(new Attack(), 1, 1, 1, 1),
             new Stat(new Defence(), 1, 1, 1, 1),
@@ -213,7 +213,7 @@ class RepositoryTest extends TestCase
     /** @test */
     public function it_should_return_the_total_experience(): void
     {
-        $this->assertSame(27, $this->repository->getTotalExperience());
+        $this->assertSame(5400000000, $this->repository->getTotalExperience());
     }
 
     /** @test */


### PR DESCRIPTION
Fixes `RS3\Stats\Repository::getTotalLevel()` and `RS3\Stats\Repository::getTotalExperience()`. Both functions were returning the wrong data (e.g `getTotalLevel()` was returning the players total experience and vice-versa.

