### PR TITLE
Fix RuneStat\validate_rsn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `RuneStat\validate_rsn` correctly validates display names with spaces
+
 ## [v0.1.2]
 
 ### Added

--- a/src/functions.php
+++ b/src/functions.php
@@ -7,7 +7,7 @@ namespace RuneStat;
 if (! function_exists('\RuneStat\validate_rsn')) {
     function validate_rsn(string $rsn): bool
     {
-        return (bool) preg_match('/^[a-z0-9\-_]{1,12}$/i', $rsn);
+        return (bool) preg_match('/^[a-z0-9\-_ ]{1,12}$/i', $rsn);
     }
 }
 

--- a/tests/ValidateRsnTest.php
+++ b/tests/ValidateRsnTest.php
@@ -16,6 +16,12 @@ class ValidateRsnTest extends TestCase
     }
 
     /** @test */
+    public function it_validates_an_rsn_with_a_space(): void
+    {
+        $this->assertTrue(validate_rsn('Old Jos'));
+    }
+
+    /** @test */
     public function it_takes_exception_to_an_rsn_that_is_too_long(): void
     {
         $this->assertFalse(validate_rsn('thisdisplaynameistoolong'));


### PR DESCRIPTION
Fixes `RuneStat\validate_rsn` when validating display names that contain spaces